### PR TITLE
BLD: switch bluesky dep to bluesky-base

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @conda-forge/pdcsdevices
+* @conda-forge/pcdsdevices

--- a/README.md
+++ b/README.md
@@ -145,5 +145,5 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@conda-forge/pdcsdevices](https://github.com/orgs/conda-forge/teams/pdcsdevices/)
+* [@conda-forge/pcdsdevices](https://github.com/orgs/conda-forge/teams/pcdsdevices/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,4 +44,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - conda-forge/pdcsdevices
+    - conda-forge/pcdsdevices

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -22,7 +22,7 @@ requirements:
     - pip
   run:
     - python >=3.9
-    - bluesky <1.11,>=1.6.5
+    - bluesky-base <1.11,>=1.6.5
     - numpy
     - ophyd
     - pandas


### PR DESCRIPTION
This avoids pulling in additional unused or optional sub-dependencies by default.
It's a small detail we've been updating in some of our other feedstocks that we missed when creating this one.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
